### PR TITLE
Style hotfix

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,0 @@
-web: yarn heroku

--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: npm start

--- a/app/assets/css/header.styl
+++ b/app/assets/css/header.styl
@@ -2,13 +2,10 @@
 
 .header
     display: flex
-    flex-flow: row wrap
+    flex-wrap: wrap
     justify-content: space-between
     padding: 10px
     background: $light-gray
-
-.header__wrap
-    margin-bottom: 20px
 
 .header__logo
     flex: auto

--- a/app/assets/css/header.styl
+++ b/app/assets/css/header.styl
@@ -2,10 +2,13 @@
 
 .header
     display: flex
-    flex-wrap: wrap
+    flex-flow: row wrap
     justify-content: space-between
     padding: 10px
     background: $light-gray
+
+.header__wrap
+    margin-bottom: 20px
 
 .header__logo
     flex: auto

--- a/app/assets/css/main.styl
+++ b/app/assets/css/main.styl
@@ -1,5 +1,8 @@
 @require 'variables'
 
+*
+    box-sizing: border-box
+
 body
     margin: 0
 

--- a/app/assets/css/main.styl
+++ b/app/assets/css/main.styl
@@ -1,6 +1,6 @@
 @require 'variables'
 
-*
+*, *:before, *:after
     box-sizing: border-box
 
 body

--- a/app/assets/css/search.styl
+++ b/app/assets/css/search.styl
@@ -5,6 +5,7 @@
     box-shadow: $shadow-3dp, inset 0px 5px 14px 0px rgba(0, 0, 0, 0.12)
     flex-direction: column
     align-items: center
+    margin: $block-margins
     padding: $padding-size
 
 .search__splash-text

--- a/app/components/Header.jsx
+++ b/app/components/Header.jsx
@@ -27,7 +27,7 @@ export default class Header extends PureComponent {
 
   render() {
     return (
-      <div className="header__wrap">
+      <div>
         <div className="header" role="banner">
           <div className="header__logo">
             <Link to="/">

--- a/app/components/Header.jsx
+++ b/app/components/Header.jsx
@@ -27,7 +27,7 @@ export default class Header extends PureComponent {
 
   render() {
     return (
-      <div className="row row--stacked">
+      <div className="header__wrap">
         <div className="header" role="banner">
           <div className="header__logo">
             <Link to="/">


### PR DESCRIPTION
Put box-sizing on everything. That's my own crutch but seemed to fix some oddities, like the creative commons positioning on mobile. Change if needed.

Not sure why the wrapping flexbox on header was causing problems.