### PR TITLE
ATLS Pulses: copyedits and dead link

### DIFF
--- a/cards/atls/card.md
+++ b/cards/atls/card.md
@@ -21,17 +21,15 @@ drugs: null
 
 In Advanced Trauma Life Support (ATLS), we learned that a carotid, femoral, and radial pulse correlates to a certain systolic blood pressure (SBP) in hypotensive trauma patients.  Specifically ATLS stated:
 
--    Carotid pulse only = SBP 60 – 70 mmHg
--    Carotid & Femoral pulse only = SBP 70 – 80 mmHg
+-    Carotid pulse only = SBP 60–70 mmHg
+-    Carotid & Femoral pulse only = SBP 70–80 mmHg
 -    Radial pulse present = SBP &gt;80 mmHg
 
 There were two studies \[[Poulton, 1988](http://www.ncbi.nlm.nih.gov/pubmed/3337405); [Deakin, 2000](http://www.ncbi.nlm.nih.gov/pubmed/10987771)\] that evaluated this paradigm.  Although very small studies, they were done by two different authors, using different methods (BP cuff vs arterial line).  Both came to the same conclusion: **ATLS overestimates SBP based on palpation of radial, femoral, & carotid pulses.** Another way to state this is, if using ATLS guidelines to guestimate BP, we are grossly underestimating the degree of hypovolemia our patients have.
 
-**Click [here](http://academiclifeinem.com/is-atls-wrong-about-palpable-blood-pressure-estimates/) for full ALiEM blogpost**
-
 ## Poulton, 1988
 
- \[[Poulton, 1988](http://www.ncbi.nlm.nih.gov/pubmed/3337405)\] "ATLS Paradigm Fails"
+"ATLS Paradigm Fails" \[[Poulton, 1988](http://www.ncbi.nlm.nih.gov/pubmed/3337405)\] 
 
  **What they did:** Manually measured SBP with sphygmomanometer in 20 hypovolemic trauma patients and compared with ATLS
 -   5/20 (25%) pts were correctly predicted by ATLS guidelines
@@ -43,21 +41,23 @@ There were two studies \[[Poulton, 1988](http://www.ncbi.nlm.nih.gov/pubmed/333
 
 ## Deakin, 2000
 
-\[[Deakin, 2000](http://www.ncbi.nlm.nih.gov/pubmed/10987771)\] "Accuracy of ATLS guidelines for predicting SBP"
+"Accuracy of ATLS guidelines for predicting SBP" \[[Deakin, 2000](http://www.ncbi.nlm.nih.gov/pubmed/10987771)\] 
 
-**What they did:** Measured SBP with arterial line in 20 pts with hypovolemic shock and compared to pulses palpated by an observer blinded to BP readings.
+**What they did:** Measured SBP with arterial line in 20 patient with hypovolemic shock and compared to pulses palpated by an observer blinded to BP readings.
 
 **What they found: **The disappearance of pulse always occurred in the following order radial &gt; femoral &gt; carotid pulse. There were 4 subgroups:
 -   Group 1: Radial, femoral, and carotid pulses present
-    -   10/12 (83%) had SBP
+    -   10/12 (83%) had SBP &lt;80 mmHg
 -   Group 2: Femoral and carotid pulses only
-    -   10/12 (83%) had SBP
+    -   10/12 (83%) had SBP &lt;70 mmHg
 -   Group 3: Carotid pulse only
     -   0/4 (0%) had SBP &gt;60 mmHg
 -   Group 4: Radial, femoral, and carotid pulses absent
-    -   2/3 (67%) had SBP
+    -   2/3 (67%) had SBP &lt;60 mmHg
 
 **Conclusion:** ATLS guidelines for assessing SBP are inaccurate and generally overestimate the patient’s SBP. 
+
+**Click [here](https://www.aliem.com/2013/is-atls-wrong-about-palpable-blood-pressure/) for full ALiEM blog post**
 
 ## References
 


### PR DESCRIPTION
Example of a blog post converted to card.
Missing some SBP measures in Deakin study 
Fixed dead link to ALiEM blog post