### PR TITLE
add dismissable announcement system

### DIFF
--- a/app/assets/css/announcements.styl
+++ b/app/assets/css/announcements.styl
@@ -1,14 +1,30 @@
-.announcements
+@require './variables'
+
+.announcement
     margin: $block-margins
     margin-top: $block-margin*-1
-    padding: 1em 3em
+    padding: 1em 0 .5em
     background-color: $light-gray
     color: $dark-gray
 
-    h2
-        color: $primary
-        border: 0
-        margin-bottom: 0
-        font-size: 1.3em
-        padding-right: 1em
-        display: inline
+.announcement_content
+    margin: auto
+    padding: 0 20px
+    width: 100%
+    max-width: $container-max-width
+
+.announcement_dismiss
+    display: inline-block
+    margin-right: 20px
+    font-weight: bold
+    color: $primary
+    float: right
+    &:hover
+        text-decoration: underline
+
+.announcement_heading
+    color: $primary
+    border: 0
+    margin-bottom: 0
+    font-size: 1.3em
+    padding-right: 25px

--- a/app/assets/css/footer.styl
+++ b/app/assets/css/footer.styl
@@ -40,10 +40,11 @@
     a
         color: $light-gray
         padding: .5em 1em
+        border-radius: 4px
         // Disabling stylint because this is a single-use item that won't be used elsewhere
         // @stylint off
         &:hover
             background-color: #252525
-            box-shadow: inset 0 1px 3px rgba(0,0,0,.5), 0 1px 0 rgba(255,255,255,0.1)
-            text-shadow: 0 1px 3px rgba(0,0,0,.5)
+            box-shadow: inset 0 1px 3px rgba(0, 0, 0, .5), 0 1px 0 rgba(255, 255, 255, .1)
+            text-shadow: 0 1px 3px rgba(0, 0, 0, .5)
         // @stylint on

--- a/app/assets/css/main.styl
+++ b/app/assets/css/main.styl
@@ -58,7 +58,7 @@ input
 for i in 12 25 50
     .column--{i}
         width: ($container-max-width * (i / 100)) - 20
-        
+
 .main
     box-sizing: border-box
     margin: 0

--- a/app/components/Announcements.tsx
+++ b/app/components/Announcements.tsx
@@ -1,11 +1,76 @@
 import * as React from 'react';
+import { gql, graphql } from 'react-apollo';
+import { Announcement as IAnnouncement } from '../../server/models/';
 
-export default () => (
-    <div className="announcements">
-        <div className="content">
-            <h2>Achtung!</h2> Lorem ipsum dolor sit amet, consectetur adipiscing elit.
-            Vestibulum lorem metus, ornare ut eleifend at, dictum nec lorem. Proin non velit odio. Nullam
-            viverra nibh at erat iaculis sollicitudin. Nulla at dignissim eros.
-        </div>
-    </div>
-);
+const LOCALSTORAGE_KEY = 'announcementId';
+
+interface Props {
+  data?: {
+    announcements: IAnnouncement[];
+    networkStatus: number;
+  };
+}
+
+interface State {
+  announcement?: IAnnouncement;
+  isDismissed: boolean;
+}
+
+const announcements = gql`
+  query getAnnouncements {
+    announcements {
+      date
+      heading
+      message
+    }
+  }
+`;
+
+@graphql(announcements)
+export default class Announcements extends React.Component<Props, State> {
+
+  static lastSeen: string|null = localStorage.getItem(LOCALSTORAGE_KEY);
+
+  constructor(props) {
+    super(props);
+    this.state = {
+      isDismissed: false,
+    };
+  }
+
+  componentWillReceiveProps(props: Props) {
+    if (props.data === undefined || props.data.networkStatus !== 7) { return; }
+    const announcement = props.data.announcements[0];
+    this.setState(prevState => ({
+      ...prevState,
+      announcement,
+      isDismissed: Announcements.lastSeen === announcement.date,
+    }));
+  }
+
+  dismiss = () => {
+    if (this.state.announcement) {
+      localStorage.setItem(LOCALSTORAGE_KEY, this.state.announcement.date);
+    }
+    this.setState(prevState => ({ ...prevState, isDismissed: true }));
+  }
+
+  render() {
+    if (!this.state.announcement || this.state.isDismissed) { return null; }
+    return (
+      <div className="announcement">
+          <div className="announcement_content">
+            <span className="foo">
+              <span className="announcement_heading" children={this.state.announcement.heading} />
+              {this.state.announcement.message}
+            </span>
+            <button
+              className="announcement_dismiss"
+              children="dismiss"
+              onClick={this.dismiss}
+            />
+          </div>
+      </div>
+    );
+  }
+}

--- a/app/components/Announcements.tsx
+++ b/app/components/Announcements.tsx
@@ -60,7 +60,7 @@ export default class Announcements extends React.Component<Props, State> {
     return (
       <div className="announcement">
           <div className="announcement_content">
-            <span className="foo">
+            <span>
               <span className="announcement_heading" children={this.state.announcement.heading} />
               {this.state.announcement.message}
             </span>

--- a/cards/announcements.yml
+++ b/cards/announcements.yml
@@ -1,0 +1,8 @@
+- date: 2016/05/06
+  heading: Hello World!
+  message: >
+    From which we spring another world, billions upon billions, a very small stage in a vast cosmic arena intelligent beings.
+    Hundreds of thousands, radio telescope galaxies Rig Veda extraplanetary muse about corpus callosum tingling of the spine
+    radio telescope of brilliant syntheses a mote of dust suspended in a sunbeam. A billion trillion tesseract the only home
+    we've ever known Drake Equation Apollonius of Perga. Another world decipherment. Birth dream of the mind's eye and billions
+    upon billions upon billions upon billions upon billions upon billions upon billions.

--- a/cards/tpa-contraindications/card.md
+++ b/cards/tpa-contraindications/card.md
@@ -12,14 +12,16 @@ categories:
 
 # Stroke: 2013 AHA Guidelines on Contraindications for Thrombolytics
 
-**INCLUSION CRITERIA**
+## Inclusion Criteria
 
 1. Diagnosis of ischemic stroke causing measurable neurologic deficit
 2. Age ≥18 years
 
-## 0-3 hours from symptom onset
+## Exclusion Criteria
 
-### Absolute Exclusion Criteria
+### 0-3 hours from symptom onset
+
+#### Absolute Exclusion Criteria
 
 - Significant head trauma or prior stroke in previous 3 months
 - Symptoms suggest subarachnoid hemorrhage
@@ -35,7 +37,7 @@ categories:
 - Blood glucose &lt;50 mg/dL (2.7 mmol/L)
 - CT shows multilobar infarct (hypodensity >1/3 cerebral hemisphere)
 
-### Relative Exclusion Criteria
+#### Relative Exclusion Criteria
 
 - Only minor or rapidly improvement stroke symptoms (clearing spontaneously)
 - Pregnancy
@@ -44,11 +46,11 @@ categories:
 - Recent GI or urinary tract hemorrhage within previous 21 days
 - Recent acute MI within previous 3 months
 
-## 3-4.5 hours from symptom onset
+### 3-4.5 hours from symptom onset
 
-### Absolute Exclusion Criteria
+#### Absolute Exclusion Criteria
 
-**_List is same as for 0-3 hour time frame above PLUS any of the following_**:
+> **_List is same as for 0-3 hour time frame above PLUS any of the following_**:
 
 - Age >80 years
 - Severe stroke (NIHSS >25)

--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
     "html-webpack-plugin": "^2.28.0",
     "husky": "^0.13.3",
     "jest": "^19.0.2",
+    "js-yaml": "^3.8.3",
     "json-loader": "^0.5.4",
     "offline-plugin": "^4.7.0",
     "react-addons-test-utils": "^15.4.2",

--- a/server/models/announcement/announcementQuery.ts
+++ b/server/models/announcement/announcementQuery.ts
@@ -1,0 +1,38 @@
+import { GraphQLInt, GraphQLList } from 'graphql';
+import { ArgumentField } from '../../utils/strongTypes';
+import sortType, { AscOrDesc } from '../misc/sortType';
+import announcementType from './announcementType';
+
+interface AnnouncementsArgs {
+  /** Limit the response to n items. */
+  limit: number;
+  /** Sort ascending or descending. */
+  sort: AscOrDesc;
+}
+
+const announcements: ArgumentField<AnnouncementsArgs> = {
+  type: new GraphQLList(announcementType),
+  description: 'Fetch a list of announcements.',
+  args: {
+    limit: {
+      description: 'Limit the response to n items.',
+      type: GraphQLInt,
+      defaultValue: 1,
+    },
+    sort: {
+      description: 'Sort order of the announcements.',
+      type: sortType,
+      defaultValue: 'desc',
+    },
+  },
+  resolve: (root, { limit, sort }: AnnouncementsArgs) => {
+    const payload = sort === 'desc'
+      ? [ ...root.announcements ]
+      : [ ...root.announcements ].reverse();
+    return payload.slice(0, limit);
+  },
+};
+
+export default {
+  announcements,
+};

--- a/server/models/announcement/announcementType.ts
+++ b/server/models/announcement/announcementType.ts
@@ -1,0 +1,32 @@
+import { GraphQLObjectType, GraphQLString } from 'graphql';
+import { TypedFields } from '../../utils/strongTypes';
+
+export interface Announcement {
+  /** Date string in the form of YYYY/MM/DD */
+  date: string;
+  /** Heading for announcement */
+  heading: string;
+  /** Announcement message */
+  message: string;
+}
+
+const fields = (): TypedFields<Announcement> => ({
+  date: {
+    description: 'Date string in the form of YYYY/MM/DD',
+    type: GraphQLString,
+  },
+  heading: {
+    description: '',
+    type: GraphQLString,
+  },
+  message: {
+    description: '',
+    type: GraphQLString,
+  },
+});
+
+export default new GraphQLObjectType({
+  name: 'Announcement',
+  description: 'Data representing a single announcement.',
+  fields,
+});

--- a/server/models/index.ts
+++ b/server/models/index.ts
@@ -2,12 +2,15 @@ export { Author, AuthorRaw } from './author/authorType';
 export { APIResponse } from './misc/apiResponseType';
 export { Card } from './card/cardType';
 export { Category } from './category/categoryType';
+export { Announcement } from './announcement/announcementType';
 
+import announcementQuery from './announcement/announcementQuery';
 import authorQuery from './author/authorQuery';
 import cardQuery from './card/cardQuery';
 import categoryQuery from './category/categoryQuery';
 
 export const queries = {
+  ...announcementQuery,
   ...authorQuery,
   ...cardQuery,
   ...categoryQuery,

--- a/server/utils/normalize.ts
+++ b/server/utils/normalize.ts
@@ -31,7 +31,9 @@ function createCategoryObj(category: string): Category {
   };
 }
 
-export const normalize = (cards: SingleCardJSON[]): RootValue => {
+type AllButAnnouncements = Pick<RootValue, 'entities'|'result'>;
+
+export const normalize = (cards: SingleCardJSON[]): AllButAnnouncements => {
   const mapped = cards.map(card => ({
     ...card,
     authors: card.authors.map(AuthorFactory.create),

--- a/server/utils/strongTypes.ts
+++ b/server/utils/strongTypes.ts
@@ -1,5 +1,5 @@
 import { GraphQLArgumentConfig, GraphQLFieldConfig, GraphQLFieldResolver, GraphQLOutputType } from 'graphql';
-import { AuthorRaw, Category } from '../models/';
+import { Announcement, AuthorRaw, Category } from '../models/';
 
 interface AuthorJSON {
   [authorId: string]: AuthorRaw;
@@ -27,6 +27,7 @@ interface CardJSON {
  * The complete shape of `data.json`
  */
 export interface RootValue {
+  announcements: Announcement[];
   entities: {
     authors: AuthorJSON;
     categories: CategoryJSON;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,8 @@
     "module": "commonjs",
     "lib": [
       "dom",
-      "es2017",
+      "es6",
+      "es2016.array.include",
       "es2017.object"
     ],
     "jsx": "react",
@@ -19,9 +20,7 @@
     "moduleResolution": "node",
     "experimentalDecorators": true
   },
-  "include": [
-    "webpack.config.ts",
-    "index.ts",
-    "./server/**/*"
+  "files": [
+    "./index.ts"
   ]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4874,7 +4874,7 @@ js-tokens@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-3.0.1.tgz#08e9f132484a2c45a30907e9dc4d5567b7f114d7"
 
-js-yaml@3.x, js-yaml@^3.4.6, js-yaml@^3.6.1, js-yaml@^3.7.0:
+js-yaml@3.x, js-yaml@^3.4.6, js-yaml@^3.6.1, js-yaml@^3.7.0, js-yaml@^3.8.3:
   version "3.8.3"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.8.3.tgz#33a05ec481c850c8875929166fe1beb61c728766"
   dependencies:


### PR DESCRIPTION
cc: @jvoros

There's quite a bit going on here so I'll spare you the nitty gritty details.

In a nutshell, this PR allows users to dismiss announcements by saving a token in localstorage. The announcements are served from a new `announcements.yml` file in the cards directory.

Let me know what you think!